### PR TITLE
explicitly destroy response buffer

### DIFF
--- a/request.js
+++ b/request.js
@@ -1011,6 +1011,9 @@ Request.prototype.readResponseBody = function (response) {
     debug('end event', self.uri.href)
     if (self._aborted) {
       debug('aborted', self.uri.href)
+      // `buffer` is defined in the parent scope and used in a closure it exists for the life of the request.
+      // This can lead to leaky behavior if the user retains a reference to the request object.
+      buffer.destroy()
       return
     }
 
@@ -1023,6 +1026,9 @@ Request.prototype.readResponseBody = function (response) {
       } else {
         response.body = buffer.toString(self.encoding)
       }
+      // `buffer` is defined in the parent scope and used in a closure it exists for the life of the Request.
+      // This can lead to leaky behavior if the user retains a reference to the request object.
+      buffer.destroy()
     } else if (strings.length) {
       // The UTF8 BOM [0xEF,0xBB,0xBF] is converted to [0xFE,0xFF] in the JS UTC16/UCS2 representation.
       // Strip this value out when the encoding is set to 'utf8', as upstream consumers won't expect it and it breaks JSON.parse().
@@ -1031,6 +1037,8 @@ Request.prototype.readResponseBody = function (response) {
       }
       response.body = strings.join('')
     }
+    
+    // explicitly destroy, since itto null which is referenced by a closure
 
     if (self._json) {
       try {

--- a/request.js
+++ b/request.js
@@ -1037,8 +1037,6 @@ Request.prototype.readResponseBody = function (response) {
       }
       response.body = strings.join('')
     }
-    
-    // explicitly destroy, since itto null which is referenced by a closure
 
     if (self._json) {
       try {


### PR DESCRIPTION
This fixes the issue mentioned in #1723. The lifetime of the `buffer` variable defined in `readResponseBody` is linked to the `Request` object, rather than the enclosing function. This can lead to leaky behavior if references to the request persist in memory.
